### PR TITLE
docker build時にcomposer installをdocker内で実行する

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,6 +9,7 @@ services :
         - '8081:80'
     volumes:
       - ./application:/var/www/application
+      - /var/www/application/service/vendor
     env_file:
       ./docker/app/.env
     tty: true

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -22,5 +22,6 @@ RUN a2enmod rewrite
 COPY application /var/www/application
 
 RUN chown -R www-data:www-data /var/www/
+RUN cd /var/www/application/service/ && composer install
 
 WORKDIR /var/www/


### PR DESCRIPTION
docker build時にcomposer instlalを実行する

DockerFile内で実行されるスクリプトはWORKDIRの場所で実行されるため、
ディレクトリ移動とinstallの実行を一つのスクリプトで実行してます
> RUN cd /var/www/application/service/ && composer install


DockerCompose のVolumeの追加については下記のVolume trickをみてもらったほうがわかりやすいかも
https://qiita.com/miyamonz/items/e0b0f86c47b26019d284
>  - /var/www/application/service/vendor

